### PR TITLE
Implement flow-control on the output pipe.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,10 +17,12 @@ function execStream (cmd, args, options) {
   })
 
   AB._read = function (n) {
+    proc.kill('SIGCONT')
   }
 
   B.on('readable', function() {
-    AB.push(B.read())
+    if (!AB.push(B.read()))
+      proc.kill('SIGSTOP')
   })
 
   B.on('end', function () {


### PR DESCRIPTION
Otherwise a slow reader on the output will cause internal stream buffers
to grow unbounded.

Note that the input pipe already has implicit flow-control via the
callback.
